### PR TITLE
Refatora site com layout base e estilo unificado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+__pycache__/
+*.pyc

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,65 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background-color: #f9f9f9;
+}
+.top-nav {
+  background-color: #e91e63;
+  padding: 10px;
+}
+.top-nav a {
+  color: #fff;
+  margin-right: 10px;
+  text-decoration: none;
+}
+.top-nav a:hover {
+  text-decoration: underline;
+}
+main {
+  padding: 20px;
+}
+.container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+.card {
+  background-color: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px;
+}
+.card img {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+}
+.card h3 {
+  margin: 10px 0 5px;
+}
+.card p {
+  margin: 5px 0;
+}
+.card a {
+  margin-top: auto;
+  display: inline-block;
+  padding: 10px 20px;
+  background-color: #4CAF50;
+  color: white;
+  text-decoration: none;
+  border-radius: 6px;
+  transition: background-color 0.3s ease;
+}
+.card a:hover {
+  background-color: #388e3c;
+}
+footer {
+  text-align: center;
+  padding: 10px;
+  background: #eee;
+  font-size: 14px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}Henrique's Digital{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <nav class="top-nav">
+        <a href="{{ url_for('index') }}">Início</a>
+        <a href="{{ url_for('catalogo') }}">Catálogo</a>
+        <a href="{{ url_for('quiz') }}">Quiz</a>
+    </nav>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/templates/catalogo.html
+++ b/templates/catalogo.html
@@ -1,118 +1,29 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-  <meta charset="UTF-8">
-  <title>Catálogo Henrique's Digital</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      background-color: #f9f9f9;
-      margin: 0;
-      padding: 0;
-    }
-
-    header {
-      background-color: #e91e63;
-      color: white;
-      padding: 20px;
-      text-align: center;
-    }
-
-    .container {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 20px;
-      padding: 20px;
-    }
-
-    .card {
-      background-color: #fff;
-      border-radius: 12px;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      padding: 15px;
-    }
-
-    .card img {
-      width: 100%;
-      max-height: 200px;
-      object-fit: cover;
-    }
-
-    .card h3 {
-      margin: 10px 0 5px;
-    }
-
-    .card p {
-      margin: 5px 0;
-    }
-
-    .card a {
-      margin-top: auto;
-      display: inline-block;
-      padding: 10px 20px;
-      background-color: #4CAF50;
-      color: white;
-      text-decoration: none;
-      border-radius: 6px;
-      transition: background-color 0.3s ease;
-    }
-
-    .card a:hover {
-      background-color: #388e3c;
-    }
-
-    footer {
-      text-align: center;
-      padding: 10px;
-      background: #eee;
-      font-size: 14px;
-    }
-  </style>
-</head>
-<body>
-
-  <header>
-    <h1>Catálogo Henrique's Digital</h1>
-    <p>Calcinhas • Cuecas • Infantil • Segunda Pele</p>
-  </header>
-
+{% extends "base.html" %}
+{% block title %}Catálogo Henrique's Digital{% endblock %}
+{% block content %}
+  <h1>Catálogo Henrique's Digital</h1>
+  <p>Calcinhas • Cuecas • Infantil • Segunda Pele</p>
   <div class="container">
-
-    <!-- Produto 1 -->
     <div class="card">
       <img src="https://via.placeholder.com/300x200?text=Calcinha+Algodao" alt="Calcinha Algodão">
       <h3>Calcinha Algodão</h3>
       <p>Atacado: R$10,00 • Varejo: R$13,00</p>
       <a href="https://wa.me/5562992002280?text=Ol%C3%A1!%20Tenho%20interesse%20na%20Calcinha%20Algod%C3%A3o.">Comprar via WhatsApp</a>
     </div>
-
-    <!-- Produto 2 -->
     <div class="card">
       <img src="https://via.placeholder.com/300x200?text=Cueca+Box+Torp" alt="Cueca Box Torp">
       <h3>Cueca Box Torp</h3>
       <p>Atacado: R$15,00 • Varejo: R$20,00</p>
       <a href="https://wa.me/5562992002280?text=Ol%C3%A1!%20Tenho%20interesse%20na%20Cueca%20Box%20Torp.">Comprar via WhatsApp</a>
     </div>
-
-    <!-- Produto 3 -->
     <div class="card">
       <img src="https://via.placeholder.com/300x200?text=Regata+Segunda+Pele" alt="Regata Segunda Pele">
       <h3>Regata Segunda Pele</h3>
       <p>Atacado: R$18,00 • Varejo: R$25,00</p>
       <a href="https://wa.me/5562992002280?text=Ol%C3%A1!%20Tenho%20interesse%20na%20Regata%20Segunda%20Pele.">Comprar via WhatsApp</a>
     </div>
-
-    <!-- Adicione mais produtos aqui conforme necessário -->
-
   </div>
-
   <footer>
     Henrique's Digital © 2025 — WhatsApp: (62) 99200-2280
   </footer>
-
-</body>
-</html>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,7 @@
-<!doctype html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Quiz de Tráfego Pago</title>
-</head>
-<body>
-    <p>👋 Olá! Vamos entender se o tráfego pago é o próximo passo para o seu negócio crescer nos próximos 90 dias. Responda esse formulário rápido e receba uma sugestão personalizada no final. Leva menos de 2 minutos!</p>
-    <a href="{{ url_for('quiz') }}">Começar agora</a>
-    <br>
-    <a href="{{ url_for('catalogo') }}">Ver catálogo de produtos</a>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Quiz de Tráfego Pago{% endblock %}
+{% block content %}
+<p>👋 Olá! Vamos entender se o tráfego pago é o próximo passo para o seu negócio crescer nos próximos 90 dias. Responda esse formulário rápido e receba uma sugestão personalizada no final. Leva menos de 2 minutos!</p>
+<a href="{{ url_for('quiz') }}">Começar agora</a><br>
+<a href="{{ url_for('catalogo') }}">Ver catálogo de produtos</a>
+{% endblock %}

--- a/templates/obrigado.html
+++ b/templates/obrigado.html
@@ -1,11 +1,6 @@
-<!doctype html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Falar depois</title>
-</head>
-<body>
-    <p>Sem problemas! Se tiver dúvidas, me chama no WhatsApp ou salve nosso contato para quando estiver pronto.</p>
-    <a href="{{ whatsapp_link }}">Falar no WhatsApp</a>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Falar depois{% endblock %}
+{% block content %}
+<p>Sem problemas! Se tiver dúvidas, me chama no WhatsApp ou salve nosso contato para quando estiver pronto.</p>
+<a href="{{ whatsapp_link }}">Falar no WhatsApp</a>
+{% endblock %}

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -1,37 +1,32 @@
-<!doctype html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Quiz</title>
-    <script>
-    function mostraMensagem(valor){
-        document.getElementById('msg_sim').style.display = valor === 'sim' ? 'block' : 'none';
-        document.getElementById('msg_nao').style.display = valor === 'nao' ? 'block' : 'none';
-    }
-    </script>
-</head>
-<body>
-    <form method="POST" action="{{ url_for('resultado') }}">
-        <label>Nome do cliente:<br>
-            <input type="text" name="nome" required>
-        </label><br>
-        <label>Nome da empresa:<br>
-            <input type="text" name="empresa" required>
-        </label><br>
-        <label>Segmento de atuação:<br>
-            <input type="text" name="segmento" required>
-        </label><br>
-        <p>Você já sabe como funcionam os anúncios online?</p>
-        <label><input type="radio" name="conhece" value="Sim" onclick="mostraMensagem('sim')" required> Sim</label>
-        <label><input type="radio" name="conhece" value="Não" onclick="mostraMensagem('nao')"> Não</label>
-        <div id="msg_sim" style="display:none;">Perfeito! Então você já sabe o quanto o tráfego pago pode ser decisivo para alavancar as vendas e aumentar sua presença digital.</div>
-        <div id="msg_nao" style="display:none;">Imagina que você tem uma loja em uma rua vazia. Anunciar online é como colocar sua vitrine no meio do maior shopping do mundo, onde todo mundo passa o tempo todo. Com o tráfego pago, você atrai as pessoas certas com orçamento controlado.</div>
-        <p>Qual a meta de crescimento do seu faturamento nos próximos 90 dias?</p>
-        <label><input type="radio" name="meta" value="10%" required>10%</label>
-        <label><input type="radio" name="meta" value="20%" required>20%</label>
-        <label><input type="radio" name="meta" value="30%" required>30%</label>
-        <br>
-        <button type="submit">Enviar</button>
-    </form>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Quiz{% endblock %}
+{% block content %}
+<form method="POST" action="{{ url_for('resultado') }}">
+    <label>Nome do cliente:<br>
+        <input type="text" name="nome" required>
+    </label><br>
+    <label>Nome da empresa:<br>
+        <input type="text" name="empresa" required>
+    </label><br>
+    <label>Segmento de atuação:<br>
+        <input type="text" name="segmento" required>
+    </label><br>
+    <p>Você já sabe como funcionam os anúncios online?</p>
+    <label><input type="radio" name="conhece" value="Sim" onclick="mostraMensagem('sim')" required> Sim</label>
+    <label><input type="radio" name="conhece" value="Não" onclick="mostraMensagem('nao')"> Não</label>
+    <div id="msg_sim" style="display:none;">Perfeito! Então você já sabe o quanto o tráfego pago pode ser decisivo para alavancar as vendas e aumentar sua presença digital.</div>
+    <div id="msg_nao" style="display:none;">Imagina que você tem uma loja em uma rua vazia. Anunciar online é como colocar sua vitrine no meio do maior shopping do mundo, onde todo mundo passa o tempo todo. Com o tráfego pago, você atrai as pessoas certas com orçamento controlado.</div>
+    <p>Qual a meta de crescimento do seu faturamento nos próximos 90 dias?</p>
+    <label><input type="radio" name="meta" value="10%" required>10%</label>
+    <label><input type="radio" name="meta" value="20%" required>20%</label>
+    <label><input type="radio" name="meta" value="30%" required>30%</label>
+    <br>
+    <button type="submit">Enviar</button>
+</form>
+<script>
+function mostraMensagem(valor){
+    document.getElementById('msg_sim').style.display = valor === 'sim' ? 'block' : 'none';
+    document.getElementById('msg_nao').style.display = valor === 'nao' ? 'block' : 'none';
+}
+</script>
+{% endblock %}

--- a/templates/resultado.html
+++ b/templates/resultado.html
@@ -1,13 +1,8 @@
-<!doctype html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Resultado</title>
-</head>
-<body>
-    <p>🎯 Com base na sua meta de crescimento, recomendamos um investimento inicial a partir de R$ 700/mês em anúncios, além do valor de gestão da campanha. Esse valor permite aplicar estratégias com volume suficiente para gerar resultados reais, previsíveis e escaláveis.</p>
-    <p>Você está de acordo com investir esse valor?</p>
-    <a href="{{ whatsapp_link }}">Sim</a>
-    <a href="{{ url_for('nao', nome=nome, segmento=segmento) }}">Não</a>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Resultado{% endblock %}
+{% block content %}
+<p>🎯 Com base na sua meta de crescimento, recomendamos um investimento inicial a partir de R$ 700/mês em anúncios, além do valor de gestão da campanha. Esse valor permite aplicar estratégias com volume suficiente para gerar resultados reais, previsíveis e escaláveis.</p>
+<p>Você está de acordo com investir esse valor?</p>
+<a href="{{ whatsapp_link }}">Sim</a>
+<a href="{{ url_for('nao', nome=nome, segmento=segmento) }}">Não</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adiciona template base com navegação para todas as páginas
- Centraliza estilos em `static/style.css`
- Atualiza páginas para usar layout compartilhado e links de WhatsApp

## Testing
- `python3 -m py_compile app.py main.py`
- `python3 app.py & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68969f5237e48331b04a57ca007c00fe